### PR TITLE
Update `heroku-cli-util` to 5.6.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: iojs-v2.0.2
+    version: 5.0.0

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/heroku/heroku-git",
   "dependencies": {
     "co": "4.6.0",
-    "heroku-cli-util": "5.4.10"
+    "heroku-cli-util": "5.6.3"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
We'd need the `HEROKU_SSL_VERIFY` fix from `heroku-cli-util` for custom API host.
